### PR TITLE
feat: Add publishing CI for `ondemand` snap

### DIFF
--- a/.github/workflows/promote-to-stable.yaml
+++ b/.github/workflows/promote-to-stable.yaml
@@ -1,0 +1,38 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Promote
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+jobs:
+  promote:
+    name: ⬆️ Promote to stable
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - name: ⬆️ Promote to stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE_STABLE }} # Expires October 30th, 2024

--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+on:
+  # Run the workflow each time new commits are pushed to the main branch.
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  get-architectures:
+    name: 🖥 Get snap architectures
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.get-architectures.outputs.architectures }}
+      architectures-list: ${{ steps.get-architectures.outputs.architectures-list }}
+    steps:
+      - name: 🖥 Get snap architectures
+        id: get-architectures
+        uses: snapcrafters/ci/get-architectures@main
+
+  release:
+    name: 🚢 Release to latest/candidate
+    needs: get-architectures
+    runs-on: ubuntu-latest
+    environment: "Candidate Branch"
+    strategy:
+      matrix:
+        architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
+    steps:
+      - name: 🚢 Release to latest/candidate
+        uses: snapcrafters/ci/release-to-candidate@main
+        with:
+          architecture: ${{ matrix.architecture }}
+          launchpad-token: ${{ secrets.LP_BUILD }}
+          store-token: ${{ secrets.SNAP_STORE_CANDIDATE }} # Expires October 30th, 2024
+          repo-token: ${{ secrets.UBUNTU_HPC_BOT_TOKEN }} # Expires October 30th, 2024
+          bot-name: "Ubuntu HPC Bot"
+          bot-email: "nuccitheboss+ubuntuhpcbot@ubuntu.com"
+
+  call-for-testing:
+    name: 📣 Create call for testing
+    needs: [release, get-architectures]
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    outputs:
+      issue-number: ${{ steps.issue.outputs.issue-number }}
+    steps:
+      - name: 📣 Create call for testing
+        id: issue
+        uses: snapcrafters/ci/call-for-testing@main
+        with:
+          architectures: ${{ needs.get-architectures.outputs.architectures }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,9 +24,10 @@ license: MIT
 website: "https://openondemand.org"
 
 base: core22
-grade: devel
+grade: stable
 confinement: classic
 compression: lzo
+architectures: [amd64, arm64, ppc64el, s390x]
 environment:
   # yamllint disable rule:line-length
   PATH: $SNAP/ondemand/gems/bin:$SNAP/passenger/bin:$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
@@ -87,7 +88,7 @@ parts:
       set -e
       HOOK_DIR=${CRAFT_PRIME}/meta/hooks
       mkdir -p ${HOOK_DIR}
-      
+
       # Set install location hooks and deps.
       cat << EOF > /etc/luarocks/config-5.3.lua
       rocks_trees = {
@@ -97,7 +98,7 @@ parts:
 
       # Setup hooks.
       luarocks install snaphelpers
-      luarocks install lualogging 1.8.2  
+      luarocks install lualogging 1.8.2
       install -m 0755 install.lua ${HOOK_DIR}/install
       install -m 0755 configure.lua ${HOOK_DIR}/configure
       mv ondemand/ ${CRAFT_PART_INSTALL}/usr/share/lua/5.3
@@ -148,7 +149,7 @@ parts:
     # yamllint disable rule:line-length
     override-build: |
       craftctl default
-      
+
       set -e
       ## Build `httpd` and openidc module.
       HTTPD_INSTALL_DIR=${CRAFT_PART_INSTALL}/httpd
@@ -160,7 +161,7 @@ parts:
       curl -fsSL -o - \
         http://archive.ubuntu.com/ubuntu/pool/universe/liba/libapache2-mod-auth-openidc/libapache2-mod-auth-openidc_2.4.15.1.orig.tar.gz | \
         tar -xzf -
-      
+
       # Build and install `httpd`.
       cd httpd-2.4.58 && ./configure \
         --prefix=${HTTPD_INSTALL_DIR} \
@@ -170,7 +171,7 @@ parts:
         --enable-mods-static="http log_config logio unixd version watchdog" \
         --enable-mods-shared="access_compat alias auth_basic authn_core authn_file authz_core authz_host authz_user autoindex deflate dir env filter headers lua mime negotiation proxy proxy_http proxy_wstunnel reqtimeout rewrite setenvif ssl status"
       make -j${CRAFT_PARALLEL_BUILD_COUNT} && make install && cd ..
-      
+
       # Build and install openidc module.
       cd mod_auth_openidc-2.4.15.1 && ./autogen.sh && ./configure \
         --prefix=${HTTPD_INSTALL_DIR} \
@@ -351,7 +352,7 @@ parts:
 
       # Install `ondemand`.
       PREFIX=${ONDEMAND_INSTALL_DIR} rake --trace install
-      
+
       # Create `VERSION` file from the project version. The `VERSION` file is required
       # by a couple of `ondemand` utilities such as `nginx_stage`.
       echo ${SNAPCRAFT_PROJECT_VERSION} > ${ONDEMAND_INSTALL_DIR}/VERSION
@@ -363,7 +364,7 @@ parts:
       cat << 'EOF' > ${ONDEMAND_INSTALL_DIR}/nginx_stage/etc/profile
       export SNAP=/snap/ondemand/current
       export SNAP_COMMON=/var/snap/ondemand/common
-      
+
       export PATH=${SNAP}/ondemand/gems/bin:${SNAP}/passenger/bin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin:${PATH}
       export GEM_PATH=${SNAP}/ondemand/gems
       export RUBYLIB=$SNAP/usr/lib/ruby/3.0.0:$SNAP/usr/lib/ruby/gems/3.0.0:$SNAP/usr/lib/$(uname -p)-linux-gnu/ruby/3.0.0:$SNAP/usr/lib/ruby/vendor_ruby/3.0.0:$SNAP/usr/lib/$(uname -p)-linux-gnu/ruby/vendor_ruby/3.0.0
@@ -378,11 +379,11 @@ parts:
       craftctl default
 
       set -e
-      # Purge `bundler` brought in by the `libruby` package. 
+      # Purge `bundler` brought in by the `libruby` package.
       #
-      # If left within the snap, Passenger will attempt to use this bundler 
-      # rather than the bundler version set in `Gemfile.lock` for each of the 
-      # interactive apps. This is will cause Passenger to bork as the bundler 
+      # If left within the snap, Passenger will attempt to use this bundler
+      # rather than the bundler version set in `Gemfile.lock` for each of the
+      # interactive apps. This is will cause Passenger to bork as the bundler
       # version the apps will activate is not what Passenger expects.
       rm -rf usr/lib/ruby/gems/3.0.0/specifications/default/bundler-2.2.22.gemspec
       rm -rf usr/lib/ruby/gems/3.0.0/gems/bundler-2.2.22


### PR DESCRIPTION
This pull request adds the `release-to-candidate` and `promote-to-stable` workflows for the ondemand snap. All the required secrets and permissions have been set up for this repository.

Also contains some formatting fixes for the _snapcraft.yaml_ recipe thanks to the .editorconfig file.